### PR TITLE
Fix Windows workflow YAML syntax error

### DIFF
--- a/.github/workflows/test-windows-wheel.yml
+++ b/.github/workflows/test-windows-wheel.yml
@@ -141,8 +141,8 @@ jobs:
         }
         
         Write-Host "Testing functionality..."
-        # Use a Python script file to avoid PowerShell string parsing issues with Japanese text
-        @"
+        # Create Python test script to avoid PowerShell string parsing issues
+        $pythonTest = @"
 import namedivider_rust
 print('✓ Module imported successfully')
 
@@ -173,6 +173,7 @@ except Exception as e:
     raise
 
 print('✓ All tests passed on Windows with Python 3.11!')
-"@ | Out-File -FilePath "test_wheel.py" -Encoding UTF8
+"@
+        $pythonTest | Out-File -FilePath "test_wheel.py" -Encoding UTF8
         python test_wheel.py
       shell: powershell


### PR DESCRIPTION
- Replace problematic PowerShell HERE-DOC syntax with variable assignment
- Fix invalid workflow syntax that was causing GitHub Actions validation errors
- Use PowerShell variable with @"..."@ syntax properly embedded in YAML
- This resolves the "Invalid workflow file" error on line 146

The issue was that PowerShell HERE-DOC (@"..."@) syntax conflicts with YAML when used directly in the run block. Using a variable assignment resolves this.

🤖 Generated with [Claude Code](https://claude.ai/code)