### PR TITLE
Update GitHub workflow to prepare PyPI-ready wheels for manual upload

### DIFF
--- a/.github/workflows/build-all-wheels.yml
+++ b/.github/workflows/build-all-wheels.yml
@@ -277,16 +277,14 @@ jobs:
           echo "❌ WARNING: Expected 30 wheels, got $total_wheels"
         fi
 
-    - name: Upload combined wheels
+    - name: Prepare dist/ for manual PyPI upload
+      run: |
+        mkdir -p final_dist
+        find dist/ -name "*.whl" -exec cp {} final_dist/ \;
+        ls -la final_dist/
+
+    - name: Upload PyPI-ready wheels as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: all-wheels-unified
-        path: dist/*/*.whl
-
-    - name: Upload to PyPI (if tagged release)
-      if: startsWith(github.ref, 'refs/tags/v')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
-        packages_dir: dist/*/
+        name: pypi-ready-wheels
+        path: final_dist/*.whl


### PR DESCRIPTION
- Add new step to collect all .whl files into final_dist/ directory
- Upload PyPI-ready wheels as separate artifact named 'pypi-ready-wheels'
- Remove automatic PyPI upload and redundant all-wheels-unified artifact
- Enable manual PyPI upload with: twine upload final_dist/*.whl

🤖 Generated with [Claude Code](https://claude.ai/code)