### PR TITLE
Rename Python package from namedivider_rust to namedivider_core

### DIFF
--- a/.github/workflows/build-all-wheels.yml
+++ b/.github/workflows/build-all-wheels.yml
@@ -200,10 +200,10 @@ jobs:
         
         # Test the wheels (bash approach for Windows UTF-8 handling)
         CIBW_TEST_COMMAND_WINDOWS: >
-          bash -c "export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; python -c \"import namedivider_rust; print('Module imported successfully'); basic = namedivider_rust.BasicNameDivider(); result1 = basic.divide_name('田中太郎'); assert str(result1) == '田中 太郎'; print('BasicNameDivider test passed'); gbdt = namedivider_rust.GBDTNameDivider(); result2 = gbdt.divide_name('佐藤花子'); assert str(result2) == '佐藤 花子'; print('GBDTNameDivider test passed'); print('All tests passed!')\""
+          bash -c "export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; python -c \"import namedivider_core; print('Module imported successfully'); basic = namedivider_core.BasicNameDivider(); result1 = basic.divide_name('田中太郎'); assert str(result1) == '田中 太郎'; print('BasicNameDivider test passed'); gbdt = namedivider_core.GBDTNameDivider(); result2 = gbdt.divide_name('佐藤花子'); assert str(result2) == '佐藤 花子'; print('GBDTNameDivider test passed'); print('All tests passed!'\""
         
         CIBW_TEST_COMMAND_MACOS: >
-          python -c "import namedivider_rust; print('Module imported successfully'); basic = namedivider_rust.BasicNameDivider(); result1 = basic.divide_name('田中太郎'); assert str(result1) == '田中 太郎'; print('BasicNameDivider test passed'); gbdt = namedivider_rust.GBDTNameDivider(); result2 = gbdt.divide_name('佐藤花子'); assert str(result2) == '佐藤 花子'; print('GBDTNameDivider test passed'); print('All tests passed!')"
+          python -c "import namedivider_core; print('Module imported successfully'); basic = namedivider_core.BasicNameDivider(); result1 = basic.divide_name('田中太郎'); assert str(result1) == '田中 太郎'; print('BasicNameDivider test passed'); gbdt = namedivider_core.GBDTNameDivider(); result2 = gbdt.divide_name('佐藤花子'); assert str(result2) == '佐藤 花子'; print('GBDTNameDivider test passed'); print('All tests passed!')"
         
         # Skip PyPy builds and 32-bit architectures
         CIBW_SKIP: "pp* *-win32 *_i686"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -138,18 +138,18 @@ jobs:
         
         # Test functionality
         python -c "
-        import namedivider_rust
+        import namedivider_core
         print('✓ Module imported successfully')
         
         # Test Basic divider
-        basic = namedivider_rust.BasicNameDivider()
+        basic = namedivider_core.BasicNameDivider()
         result1 = basic.divide_name('田中太郎')
         print(f'Basic result: {result1}')
         assert str(result1) == '田中 太郎'
         print('✓ BasicNameDivider test passed')
         
         # Test GBDT divider  
-        gbdt = namedivider_rust.GBDTNameDivider()
+        gbdt = namedivider_core.GBDTNameDivider()
         result2 = gbdt.divide_name('佐藤花子')
         print(f'GBDT result: {result2}')
         assert str(result2) == '佐藤 花子'

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Python版より数十倍オーダーで速いです。
 現在はLinux (x64) Python 3.11用のwheelのみ提供しています：
 
 ```bash
-pip install https://github.com/rskmoi/namedivider-rs/releases/download/v0.2.0/namedivider_rust-0.1.0-cp311-cp311-linux_x86_64.whl
+pip install https://github.com/rskmoi/namedivider-rs/releases/download/v0.2.0/namedivider_core-0.2.0-cp311-cp311-linux_x86_64.whl
 ```
 
 ライセンスはpython実装と同じです。他のプラットフォームやPythonバージョン用のwheelは順次提供予定です。

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
-name = "namedivider_rust"
+name = "namedivider_core"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
 
 [project]
-name = "namedivider-rust"
+name = "namedivider-core"
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -162,7 +162,7 @@ impl PyGBDTNameDivider {
 }
 
 #[pymodule]
-fn namedivider_rust(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn namedivider_core(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDividedName>()?;
     m.add_class::<PyBasicNameDivider>()?;
     m.add_class::<PyGBDTNameDivider>()?;


### PR DESCRIPTION
- Update python/Cargo.toml: lib.name changed to namedivider_core
- Update python/pyproject.toml: project.name changed to namedivider-core
- Update python/src/lib.rs: pymodule name changed to namedivider_core
- Update GitHub Actions workflows to use namedivider_core imports
- Update README.md wheel file reference
- Successfully tested local build and import functionality

🤖 Generated with [Claude Code](https://claude.ai/code)