### PR TITLE
Fix CI test command quote escaping issues

### DIFF
--- a/.github/test_script.py
+++ b/.github/test_script.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""
+Test script for namedivider_core package
+Used by CI/CD to validate wheel functionality
+"""
+
+import namedivider_core
+
+def main():
+    print('Module imported successfully')
+    
+    # Test Basic divider
+    basic = namedivider_core.BasicNameDivider()
+    result1 = basic.divide_name('田中太郎')
+    assert str(result1) == '田中 太郎'
+    print('BasicNameDivider test passed')
+    
+    # Test GBDT divider
+    gbdt = namedivider_core.GBDTNameDivider()
+    result2 = gbdt.divide_name('佐藤花子')
+    assert str(result2) == '佐藤 花子'
+    print('GBDTNameDivider test passed')
+    
+    print('All tests passed!')
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/build-all-wheels.yml
+++ b/.github/workflows/build-all-wheels.yml
@@ -201,12 +201,12 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET="14.0"
           PATH="$HOME/.cargo/bin:$PATH"
         
-        # Test the wheels (bash approach for Windows UTF-8 handling)
+        # Test the wheels using external test script to avoid quote escaping issues
         CIBW_TEST_COMMAND_WINDOWS: >
-          bash -c "export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; python -c \"import namedivider_core; print('Module imported successfully'); basic = namedivider_core.BasicNameDivider(); result1 = basic.divide_name('田中太郎'); assert str(result1) == '田中 太郎'; print('BasicNameDivider test passed'); gbdt = namedivider_core.GBDTNameDivider(); result2 = gbdt.divide_name('佐藤花子'); assert str(result2) == '佐藤 花子'; print('GBDTNameDivider test passed'); print('All tests passed!'\""
+          bash -c "export LANG=en_US.UTF-8; export LC_ALL=en_US.UTF-8; python .github/test_script.py"
         
         CIBW_TEST_COMMAND_MACOS: >
-          python -c "import namedivider_core; print('Module imported successfully'); basic = namedivider_core.BasicNameDivider(); result1 = basic.divide_name('田中太郎'); assert str(result1) == '田中 太郎'; print('BasicNameDivider test passed'); gbdt = namedivider_core.GBDTNameDivider(); result2 = gbdt.divide_name('佐藤花子'); assert str(result2) == '佐藤 花子'; print('GBDTNameDivider test passed'); print('All tests passed!')"
+          python .github/test_script.py
         
         # Skip PyPy builds and 32-bit architectures
         CIBW_SKIP: "pp* *-win32 *_i686"

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -136,27 +136,8 @@ jobs:
         python -m pip install --force-reinstall dist/*.whl
         echo "✓ Wheel installed successfully"
         
-        # Test functionality
-        python -c "
-        import namedivider_core
-        print('✓ Module imported successfully')
-        
-        # Test Basic divider
-        basic = namedivider_core.BasicNameDivider()
-        result1 = basic.divide_name('田中太郎')
-        print(f'Basic result: {result1}')
-        assert str(result1) == '田中 太郎'
-        print('✓ BasicNameDivider test passed')
-        
-        # Test GBDT divider  
-        gbdt = namedivider_core.GBDTNameDivider()
-        result2 = gbdt.divide_name('佐藤花子')
-        print(f'GBDT result: {result2}')
-        assert str(result2) == '佐藤 花子'
-        print('✓ GBDTNameDivider test passed')
-        
-        print('✓ All functionality tests passed!')
-        "
+        # Test functionality using external script
+        python .github/test_script.py
 
     - name: Build Summary
       run: |


### PR DESCRIPTION
- Extract test logic to .github/test_script.py to avoid complex quote escaping
- Simplify CIBW_TEST_COMMAND_WINDOWS and CIBW_TEST_COMMAND_MACOS
- Update both build-all-wheels.yml and test-build.yml workflows
- Resolves build failures caused by malformed Python inline commands

🤖 Generated with [Claude Code](https://claude.ai/code)